### PR TITLE
Add using where Terminal.Gui now requires disposals

### DIFF
--- a/ii/MainWindow.cs
+++ b/ii/MainWindow.cs
@@ -430,7 +430,7 @@ G - creates a regex pattern that matches only the failing part(s)
 
     private void OpenReport()
     {
-        var ofd = new OpenDialog("Load CSV Report", "Enter file path to load")
+        using var ofd = new OpenDialog("Load CSV Report", "Enter file path to load")
         {
             AllowedFileTypes = new[] {".csv"}, 
             CanChooseDirectories = false,
@@ -457,12 +457,12 @@ G - creates a regex pattern that matches only the failing part(s)
 
         var cts = new CancellationTokenSource();
 
-        var btn = new Button("Cancel");
+        using var btn = new Button("Cancel");
         Action cancelFunc = ()=>{cts.Cancel();};
         Action closeFunc = ()=>{Application.RequestStop();};
         btn.Clicked += cancelFunc;
 
-        var dlg = new Dialog("Opening",MainWindow.DlgWidth,5,btn);
+        using var dlg = new Dialog("Opening",MainWindow.DlgWidth,5,btn);
         var rows = new Label($"Loaded: 0 rows"){
             Width = Dim.Fill() };
         dlg.Add(rows);
@@ -540,7 +540,7 @@ G - creates a regex pattern that matches only the failing part(s)
         var result = default(T);
         bool optionChosen = false;
 
-        var dlg = new Dialog(title, Math.Min(Console.WindowWidth,DlgWidth), DlgHeight);
+        using var dlg = new Dialog(title, Math.Min(Console.WindowWidth,DlgWidth), DlgHeight);
             
         var line = DlgHeight - (DlgBoundary)*2 - options.Length;
 
@@ -603,7 +603,7 @@ G - creates a regex pattern that matches only the failing part(s)
     {
         bool optionChosen = false;
 
-        var dlg = new Dialog(title, Math.Min(Console.WindowWidth,DlgWidth), DlgHeight);
+        using var dlg = new Dialog(title, Math.Min(Console.WindowWidth,DlgWidth), DlgHeight);
 
         var line = DlgHeight - (DlgBoundary)*2 - 2;
 

--- a/ii/Views/RulesView.cs
+++ b/ii/Views/RulesView.cs
@@ -212,7 +212,7 @@ class RulesView : View
 
     private void Activate(OutstandingFailureNode ofn)
     {
-        var ignore = new Button("Ignore");
+        using var ignore = new Button("Ignore");
         ignore.Clicked += ()=> {
             try
             {
@@ -226,7 +226,7 @@ class RulesView : View
             Application.RequestStop();
         };
 
-        var update = new Button("Update");
+        using var update = new Button("Update");
         update.Clicked += ()=>{
             try
             {
@@ -240,10 +240,10 @@ class RulesView : View
             Application.RequestStop();
         };
             
-        var cancel = new Button("Cancel");
+        using var cancel = new Button("Cancel");
         cancel.Clicked += ()=>{Application.RequestStop();};
 
-        var dlg = new Dialog("Failure",MainWindow.DlgWidth,MainWindow.DlgHeight,ignore,update,cancel);
+        using var dlg = new Dialog("Failure",MainWindow.DlgWidth,MainWindow.DlgHeight,ignore,update,cancel);
 
         var lbl = new FailureView(){
             X = 0,
@@ -341,12 +341,12 @@ class RulesView : View
 
         var cts = new CancellationTokenSource();
 
-        var btn = new Button("Cancel");
+        using var btn = new Button("Cancel");
         Action cancelFunc = ()=>{cts.Cancel();};
         Action closeFunc = ()=>{Application.RequestStop();};
         btn.Clicked += cancelFunc;
 
-        var dlg = new Dialog("Evaluating",MainWindow.DlgWidth,6,btn);
+        using var dlg = new Dialog("Evaluating",MainWindow.DlgWidth,6,btn);
 
         var stage = new Label("Evaluating Failures"){Width = Dim.Fill(), X = 0,Y = 0};
         var progress = new ProgressBar(){Height= 2,Width = Dim.Fill(), X=0,Y = 1};


### PR DESCRIPTION
Add disposals where Terminal.Gui now needs them following the 1.7.0 update merged in #128 
_Should_ be safe - the objects are all used modally within the containing method...