### PR TITLE
Support for only running on top X records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Added
 
+- New flag `--top` to only run on a subset of the data available (e.g. `top 1000`).  Currently only supported by relational database and csv runners
 - Added ability to ignore whole columns in reviewer by pressing `Del` on the column and confirming
 
 ## Fixed

--- a/IsIdentifiable/Options/IsIdentifiableBaseOptions.cs
+++ b/IsIdentifiable/Options/IsIdentifiableBaseOptions.cs
@@ -144,6 +144,12 @@ public class IsIdentifiableBaseOptions
     public int? MaxValidationCacheSize { get; set; } = MaxValidationCacheSizeDefault;
 
     /// <summary>
+    /// Optional.  Set to a stop processing after x records e.g. only evalute top 1000 records of a table/file.  Currently only supported for csv/database
+    /// </summary>
+    [Option(HelpText = "Optional.  Set to stop processing after x records e.g. only evalute top 1000 records of a table/file.  Currently only supported for csv/database", Default = -1)]
+    public int Top { get; set; } = -1;
+
+    /// <summary>
     /// Default for <see cref="MaxValidationCacheSize"/>
     /// </summary>
     public const int MaxValidationCacheSizeDefault = 1_000_000;
@@ -165,6 +171,7 @@ public class IsIdentifiableBaseOptions
     /// <see cref="GetTargetName"/> and so not respect this property.</para>
     /// </summary>
     public string TargetName { get; set; } = TargetNameDefault;
+
 
     /// <summary>
     /// Returns a short string with no spaces or punctuation that describes the target.  This will be used
@@ -254,5 +261,9 @@ public class IsIdentifiableBaseOptions
 
         if (MaxValidationCacheSize == MaxValidationCacheSizeDefault && globalOpts.MaxValidationCacheSize.HasValue)
             MaxValidationCacheSize = globalOpts.MaxValidationCacheSize.Value;
+
+        // if global options specifies to only run on x records and we don't have an explicit declaration for that property
+        if (Top <= 0 && globalOpts.Top > 0)
+            Top = globalOpts.Top;
     }
 }

--- a/IsIdentifiable/Runners/FileRunner.cs
+++ b/IsIdentifiable/Runners/FileRunner.cs
@@ -49,10 +49,18 @@ public class FileRunner : IsIdentifiableAbstractRunner
 
                 _logger.Info($"Headers are:{string.Join(",", r.HeaderRecord)}");
 
+                int done = 0;
+
                 while(r.Read())
                 {
                     foreach (Failure failure in GetFailuresIfAny(r))
                         AddToReports(failure);
+                    
+                    done++;
+
+                    // if we have done all we were asked to do then stop
+                    if (_opts.Top > 0 && done >= _opts.Top)
+                        break;                    
                 }
                 
                 CloseReports();

--- a/Tests/IsIdentifiableTests/RunnerTests/FileRunnerTests.cs
+++ b/Tests/IsIdentifiableTests/RunnerTests/FileRunnerTests.cs
@@ -40,4 +40,40 @@ class FileRunnerTests
 
         reporter.Verify();
     }
+
+    [Test]
+    public void FileRunner_TopX()
+    {
+        var fi = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "testfile.csv"));
+        using (var s = fi.CreateText())
+        {
+            s.WriteLine("Fish,Chi,Bob");
+            
+            // create a 100 line file
+            for(int i=0;i<100;i++)
+                s.WriteLine("123,0102821172,32 Ankleberry lane");
+
+            s.Flush();
+            s.Close();
+        }
+
+        var runner = new FileRunner(new IsIdentifiableFileOptions() { File = fi, StoreReport = true, Top = 22 });
+
+        var reporter = new Mock<IFailureReport>(MockBehavior.Strict);
+
+        int done = 0;
+
+        reporter.Setup(f => f.Add(It.IsAny<Failure>())).Callback<Failure>(f => Assert.AreEqual("0102821172", f.ProblemValue));
+        reporter.Setup(f => f.DoneRows(1)).Callback(()=>done++);
+        reporter.Setup(f => f.CloseReport());
+
+
+        runner.Reports.Add(reporter.Object);
+
+        runner.Run();
+
+        reporter.Verify();
+
+        Assert.AreEqual(22, done);
+    }
 }


### PR DESCRIPTION
Fixes #185

```
PS D:\Repos\IsIdentifiable\ii\bin\Debug\net6.0> ./ii file -f D:\temp\Demography.csv --top 100 --storereport
2022-09-01 13:12:02.7501| INFO|IsIdentifiable.Runners.FileRunner|Headers are:chi,dtCreated,current_record,notes,chi_num_of_curr_record,chi_status,century,surname,forename,sex,current_address_L1,current_address_L2,current_address_L3,current_address_L4,current_postcode,date_of_death,source_death,area_residence,hb_extract,current_gp,birth_surname,previous_surname,midname,alt_forename,other_initials,previous_address_L1,previous_address_L2,previous_address_L3,previous_address_L4,previous_postcode,date_address_changed,adr,current_gp_accept_date,previous_gp,previous_gp_accept_date,date_into_practice,date_of_birth,patient_triage_score,hic_dataLoadRunID||
2022-09-01 13:12:02.8071|TRACE|IsIdentifiable.Runners.IsIdentifiableAbstractRunner|Done 100 rows||
2022-09-01 13:12:02.8071| INFO|IsIdentifiable.Runners.IsIdentifiableAbstractRunner|Total runtime for FileRunner:00:00:00.0882868||
2022-09-01 13:12:02.8071| INFO|IsIdentifiable.Runners.IsIdentifiableAbstractRunner|ValidateCacheHits:2702 Total ValidateCacheMisses:1198||
2022-09-01 13:12:02.8071| INFO|IsIdentifiable.Runners.IsIdentifiableAbstractRunner|Total FailurePart identified: 1088||
```