### PR TITLE
fix dependabot config tagging Thomas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  reviewers:
+  - jas88
+  - rkm
 - package-ecosystem: nuget
   directory: "/"
   schedule:
     interval: daily
   reviewers:
-  - tznind
   - jas88
   - rkm
 - package-ecosystem: maven


### PR DESCRIPTION
This is resulting in an error since Thomas is no longer part of the SMI organisation.