### PR TITLE
Validate the date part of each possible CHI before complaining

### DIFF
--- a/Tests/IsIdentifiableTests/IsIdentifiable_TestRegexDetections.cs
+++ b/Tests/IsIdentifiableTests/IsIdentifiable_TestRegexDetections.cs
@@ -22,7 +22,16 @@ public class IsIdentifiableRunnerTests
 
         Assert.AreEqual("0101010101", p.Word);
         Assert.AreEqual(10, p.Offset);
-    } 
+    }
+
+    [Test]
+    public void TestChiBadDate()
+    {
+        var runner = new TestRunner("2902810123 would be a CHI if 1981 had been a leap year");
+        runner.Run();
+        Assert.IsEmpty(runner.ResultsOfValidate);
+    }
+    
     [Test]
     public void TestCaching()
     {


### PR DESCRIPTION
- Check the date part of each number matching a CHI regex is actually a real date
- Add test case for above (1981 was not a leap year, so 2902810123 is not a valid CHI despite looking like one)
- Fixes #216 