### PR TITLE
support skipping validation of safe pixel data

### DIFF
--- a/IsIdentifiable/Options/IsIdentifiableDicomFileOptions.cs
+++ b/IsIdentifiable/Options/IsIdentifiableDicomFileOptions.cs
@@ -61,6 +61,13 @@ public class IsIdentifiableDicomFileOptions : IsIdentifiableOptions
     public uint IgnoreTextLessThan { get; set; } = 0;
 
     /// <summary>
+    /// Optional. If true, skip pixel data validation for "safe" combinations of Modality and ImageType e.g., 'ORIGINAL/PRIMARY' CT and MR
+    /// </summary>
+    [Option(HelpText = "Optional. If true, skip pixel data validation for \"safe\" combinations of Modality and ImageType e.g., 'ORIGINAL/PRIMARY' CT and MR")]
+    public bool SkipSafePixelValidation { get; set; } = false;
+
+
+    /// <summary>
     /// Usage examples for running IsIdentifiable on dicom files
     /// </summary>
     [Usage]

--- a/IsIdentifiable/Reporting/Reports/PixelTextFailureReport.cs
+++ b/IsIdentifiable/Reporting/Reports/PixelTextFailureReport.cs
@@ -46,7 +46,7 @@ internal class PixelTextFailureReport : FailureReport
     }
 
     //TODO Replace argument list with object
-    public void FoundPixelData(IFileInfo fi, string sopID, string studyID, string seriesID, string modality, string[] imageType, float meanConfidence, int textLength, string pixelText, int rotation, int frame, int overlay)
+    public void FoundPixelData(IFileInfo fi, string sopID, string studyID, string seriesID, string modality, string?[] imageType, float meanConfidence, int textLength, string pixelText, int rotation, int frame, int overlay)
     {
         var dr = _dt.Rows.Add();
 

--- a/IsIdentifiable/Runners/DicomFileRunner.cs
+++ b/IsIdentifiable/Runners/DicomFileRunner.cs
@@ -56,6 +56,17 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
     public bool ThrowOnError { get; set; } = true;
 
     /// <summary>
+    /// Total number of files validated
+    /// </summary>
+    public int FilesValidated { get; private set; } = 0;
+
+    /// <summary>
+    /// Total number of files with pixel data validated
+    /// </summary>
+    public int PixelFilesValidated { get; private set; } = 0;
+
+
+    /// <summary>
     /// Creates a new instance based on the <paramref name="opts"/>.  Options include what
     /// reports to write out, wether to perform OCR etc.
     /// </summary>
@@ -182,15 +193,37 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
         }
 
         var dicomFile = DicomFile.Open(fi.FullName);
-        var dataSet = dicomFile.Dataset;
+        var ds = dicomFile.Dataset;
+        var modality = GetTagOrUnknown(ds, DicomTag.Modality);
+        var imageTypeArr = GetImageType(ds);
 
-        if (_tesseractEngine != null)
-            ValidateDicomPixelData(fi, dicomFile, dataSet);
+        if (_tesseractEngine != null && ShouldValidatePixelData(modality, imageTypeArr))
+        {
+            ValidateDicomPixelData(fi, dicomFile, ds, modality, imageTypeArr);
+            PixelFilesValidated += 1;
+        }
 
-        foreach (var dicomItem in dataSet)
-            ValidateDicomItem(fi, dicomFile, dataSet, dicomItem);
+        foreach (var dicomItem in ds)
+            ValidateDicomItem(fi, dicomFile, ds, dicomItem);
 
+        FilesValidated += 1;
         DoneRows(1);
+    }
+
+    private bool ShouldValidatePixelData(string? modality, string?[] imageTypeArr)
+    {
+        if (modality == "SR")
+            return false;
+
+        if (
+            _opts.SkipSafePixelValidation &&
+            (modality == "CT" || modality == "MR") &&
+            imageTypeArr[0] == "ORIGINAL" &&
+            imageTypeArr[1] == "PRIMARY"
+        )
+            return false;
+
+        return true;
     }
 
     private void ValidateDicomItem(IFileInfo fi, DicomFile dicomFile, DicomDataset dataset, DicomItem dicomItem)
@@ -253,16 +286,11 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
             AddToReports(FailureFrom(fi, dicomFile, fieldValue, tagName, parts));
     }
 
-    void ValidateDicomPixelData(IFileInfo fi, DicomFile dicomFile, DicomDataset ds)
+    void ValidateDicomPixelData(IFileInfo fi, DicomFile dicomFile, DicomDataset ds, string? modality, string?[] imageTypeArr)
     {
-        var modality = GetTagOrUnknown(ds, DicomTag.Modality);
-        var imageType = GetImageType(ds);
         var studyID = GetTagOrUnknown(ds, DicomTag.StudyInstanceUID);
         var seriesID = GetTagOrUnknown(ds, DicomTag.SeriesInstanceUID);
         var sopID = GetTagOrUnknown(ds, DicomTag.SOPInstanceUID);
-
-        // Don't go looking for images in structured reports
-        if (modality == "SR") return;
 
         _logger.Info($"Processing '{fi.FullName}'");
         try
@@ -271,7 +299,7 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
             var numFrames = dicomImageObj.NumberOfFrames;
             for (var frameNum = 0; frameNum < numFrames; frameNum++)
             {
-                _logger.Info($" Frame {frameNum} in '{fi.FullName}'");
+                _logger.Info($"Frame {frameNum} in '{fi.FullName}'");
                 dicomImageObj.OverlayColor = 0xffffff; // white, as default magenta not good for tesseract
                 var dicomImage = dicomImageObj.RenderImage(frameNum).AsSharpImage();
                 using var memStreamOut = new System.IO.MemoryStream();
@@ -281,16 +309,16 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
                     dicomImage.SaveAsBmp(ms);
                     ms.Position = 0;
                     mi.Read(ms);
-                    ProcessBitmapMemStream(ms.ToArray(), fi, dicomFile, sopID, studyID, seriesID, modality, imageType, 0, frameNum);
+                    ProcessBitmapMemStream(ms.ToArray(), fi, dicomFile, sopID, studyID, seriesID, modality, imageTypeArr, 0, frameNum);
                 }
 
                 // Threshold the image to monochrome using a window size of 25 square
                 // The size 25 was determined empirically based on real images (could be larger, less effective if smaller)
                 mi.AdaptiveThreshold(25, 25);
-                ProcessBitmapMemStream(mi, false, fi, dicomFile, sopID, studyID, seriesID, modality, imageType, 0, frameNum);
+                ProcessBitmapMemStream(mi, false, fi, dicomFile, sopID, studyID, seriesID, modality, imageTypeArr, 0, frameNum);
                 // Tesseract only works with black text on white background so run again negated
                 mi.Negate();
-                ProcessBitmapMemStream(mi, false, fi, dicomFile, sopID, studyID, seriesID, modality, imageType, 0, frameNum);
+                ProcessBitmapMemStream(mi, false, fi, dicomFile, sopID, studyID, seriesID, modality, imageTypeArr, 0, frameNum);
 
                 // Need to threshold and possibly negate the image for best results
                 // Magick.NET won't read from Bitmap directly in .net core so go via MemoryStream
@@ -305,7 +333,7 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
                     using var ms = new System.IO.MemoryStream();
                     dicomImage.Mutate(x => x.Rotate(RotateMode.Rotate90));
                     dicomImage.SaveAsBmp(ms);
-                    ProcessBitmapMemStream(ms.ToArray(), fi, dicomFile, sopID, studyID, seriesID, modality, imageType,
+                    ProcessBitmapMemStream(ms.ToArray(), fi, dicomFile, sopID, studyID, seriesID, modality, imageTypeArr,
                         (i + 1) * 90, frameNum);
                 }
             }
@@ -364,7 +392,7 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
                     //magick_image.Write($"{fi.FullName}.ov{group-0x6000}.frame{ovframenum}.png", MagickFormat.Png);
                     // Tesseract only works with black text on white background so run again negated
                     magick_image.Negate();
-                    ProcessBitmapMemStream(magick_image, true, fi, dicomFile, sopID, studyID, seriesID, modality, imageType, 0, group, ovframenum);
+                    ProcessBitmapMemStream(magick_image, true, fi, dicomFile, sopID, studyID, seriesID, modality, imageTypeArr, 0, group, ovframenum);
                 }
 
             }
@@ -386,7 +414,7 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
     }
 
     private void ProcessBitmapMemStream(byte[] bytes, IFileInfo fi, DicomFile dicomFile, string sopID,
-        string studyID, string seriesID, string modality, string[] imageType, int rotationIfAny = 0,
+        string studyID, string seriesID, string modality, string?[] imageType, int rotationIfAny = 0,
         int frame = -1, int overlay = -1)
     {
         float meanConfidence;
@@ -430,7 +458,7 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
     /// <param name="rotationIfAny"></param>
     /// <param name="frame"></param>
     /// <param name="overlay"></param>
-    private void ProcessBitmapMemStream(MagickImage mi, bool forcePgm, IFileInfo fi, DicomFile dicomFile, string sopID, string studyID, string seriesID, string modality, string[] imageType, int rotationIfAny = 0, int frame = -1, int overlay = -1)
+    private void ProcessBitmapMemStream(MagickImage mi, bool forcePgm, IFileInfo fi, DicomFile dicomFile, string sopID, string studyID, string seriesID, string modality, string?[] imageType, int rotationIfAny = 0, int frame = -1, int overlay = -1)
     {
         byte[] bytes;
         using (System.IO.MemoryStream ms = new())
@@ -450,9 +478,9 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
     /// </summary>
     /// <param name="ds"></param>
     /// <returns></returns>
-    static string[] GetImageType(DicomDataset ds)
+    static string?[] GetImageType(DicomDataset ds)
     {
-        var result = new string[3];
+        var result = new string?[3];
 
         if (ds.Contains(DicomTag.ImageType))
         {
@@ -484,7 +512,7 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
     /// <param name="ds"></param>
     /// <param name="dt"></param>
     /// <returns></returns>
-    private static string GetTagOrUnknown(DicomDataset ds, DicomTag dt)
+    private static string? GetTagOrUnknown(DicomDataset ds, DicomTag dt)
     {
         return ds.Contains(dt) ? ds.GetValue<string>(dt, 0) : null;
     }

--- a/IsIdentifiable/Runners/DicomFileRunner.cs
+++ b/IsIdentifiable/Runners/DicomFileRunner.cs
@@ -537,4 +537,12 @@ public class DicomFileRunner : IsIdentifiableAbstractRunner
             ProblemField = problemField
         };
     }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        var pixelPercent = 100.0 * PixelFilesValidated / FilesValidated;
+        _logger?.Info($"Files validated: {FilesValidated}. With pixel data: {PixelFilesValidated} ({pixelPercent:0.00}%)");
+    }
 }


### PR DESCRIPTION
Refactor to allow skipping validation of pixel data which we know to be safe.

This is currently hardcoded to be ORIGINAL/PRIMARY CT and MRs, but we can add support for customisation in future if needed.