### PR TITLE
Revert "Bump NLog from 5.3.2 to 5.3.3"

### DIFF
--- a/IsIdentifiablePlugin/IsIdentifiablePlugin.csproj
+++ b/IsIdentifiablePlugin/IsIdentifiablePlugin.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="CsvHelper" />
     <PackageReference Include="HIC.RDMP.Plugin" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
-    <PackageReference Include="NLog" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IsIdentifiable\IsIdentifiable.csproj" />


### PR DESCRIPTION
Reverts SMI/IsIdentifiable#547 due to https://github.com/dependabot/dependabot-core/issues/10459