### PR TITLE
Revert "Bump CsvHelper from 32.0.3 to 33.0.1"

### DIFF
--- a/IsIdentifiablePlugin/IsIdentifiablePlugin.csproj
+++ b/IsIdentifiablePlugin/IsIdentifiablePlugin.csproj
@@ -5,7 +5,6 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CsvHelper" />
     <PackageReference Include="HIC.RDMP.Plugin" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="NLog" />


### PR DESCRIPTION
Reverts SMI/IsIdentifiable#542 due to https://github.com/dependabot/dependabot-core/issues/10459