### PR TITLE
Tidy RegexRule, annotate some nullables

### DIFF
--- a/IsIdentifiable/Rules/AllowListRule.cs
+++ b/IsIdentifiable/Rules/AllowListRule.cs
@@ -68,7 +68,7 @@ public class AllowlistRule : RegexRule
     /// A fake method due to inheriting IAppliableRule; never called.
     /// </summary>
     /// <exception cref="NotSupportedException"></exception>
-    public override RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart> badParts)
+    public override RuleAction Apply(string fieldName, string fieldValue, out List<FailurePart> badParts)
     {
         throw new NotSupportedException("This method should not be used for AllowlistRule, use ApplyAllowlistRule instead");
     }

--- a/IsIdentifiable/Rules/AllowListRule.cs
+++ b/IsIdentifiable/Rules/AllowListRule.cs
@@ -1,4 +1,4 @@
-﻿using IsIdentifiable.Failures;
+using IsIdentifiable.Failures;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/IsIdentifiable/Rules/ConsensusRule.cs
+++ b/IsIdentifiable/Rules/ConsensusRule.cs
@@ -22,7 +22,7 @@ public class ConsensusRule : IAppliableRule
     /// <param name="fieldValue"></param>
     /// <param name="badParts"></param>
     /// <returns></returns>
-    public RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart> badParts)
+    public RuleAction Apply(string fieldName, string fieldValue, out List<FailurePart> badParts)
     {
         RuleAction? firstRuleOperation = null;
         var parts = new List<FailurePart>();
@@ -43,7 +43,7 @@ public class ConsensusRule : IAppliableRule
                 // There is not consensus on whether the value should be classified as bad
                 if (newOperation != firstRuleOperation)
                 {
-                    badParts = Array.Empty<FailurePart>();
+                    badParts = new List<FailurePart>();
                     return RuleAction.None;
                 }
 
@@ -55,7 +55,7 @@ public class ConsensusRule : IAppliableRule
 
                     //do not report anything
 
-                    badParts = Array.Empty<FailurePart>();
+                    badParts = new List<FailurePart>();
                     return RuleAction.None;
                 }
             }
@@ -63,7 +63,7 @@ public class ConsensusRule : IAppliableRule
             //if anyone wants no action taken at any point stop consulting others.  Either they will agree in which case we have wasted time or they disagree so we say there is no consensus
             if (firstRuleOperation == RuleAction.None)
             {
-                badParts = Array.Empty<FailurePart>();
+                badParts = new List<FailurePart>();
                 return RuleAction.None;
             }
         }

--- a/IsIdentifiable/Rules/IAppliableRule.cs
+++ b/IsIdentifiable/Rules/IAppliableRule.cs
@@ -16,5 +16,5 @@ public interface IAppliableRule
     /// <param name="fieldValue">The value that should be validated e.g. "0101010101"</param>
     /// <param name="badParts"></param>
     /// <returns>Action to take if any as a result of applying the rule</returns>
-    RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart>? badParts);
+    RuleAction Apply(string fieldName, string fieldValue, out List<FailurePart>? badParts);
 }

--- a/IsIdentifiable/Rules/IAppliableRule.cs
+++ b/IsIdentifiable/Rules/IAppliableRule.cs
@@ -16,5 +16,5 @@ public interface IAppliableRule
     /// <param name="fieldValue">The value that should be validated e.g. "0101010101"</param>
     /// <param name="badParts"></param>
     /// <returns>Action to take if any as a result of applying the rule</returns>
-    RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart> badParts);
+    RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart>? badParts);
 }

--- a/IsIdentifiable/Rules/IRegexRule.cs
+++ b/IsIdentifiable/Rules/IRegexRule.cs
@@ -26,7 +26,7 @@ public interface IRegexRule : IAppliableRule
     /// <summary>
     /// The Regex pattern which should be used to match values with
     /// </summary>
-    string IfPattern { get; }
+    string? IfPattern { get; }
 
     /// <summary>
     /// Whether the IfPattern match is case sensitive (default is false)

--- a/IsIdentifiable/Rules/SocketRule.cs
+++ b/IsIdentifiable/Rules/SocketRule.cs
@@ -37,7 +37,7 @@ public class SocketRule : IAppliableRule, IDisposable
     public int Port { get; set; }
 
     private TcpClient _tcp;
-    private NetworkStream _stream;
+    private NetworkStream? _stream;
     private System.IO.StreamWriter _write;
     private System.IO.StreamReader _read;
 
@@ -51,7 +51,7 @@ public class SocketRule : IAppliableRule, IDisposable
     /// are identifiable according to the remote classification service</param>
     /// <returns>Whether the full <paramref name="fieldValue"/> passed validation or should be reported</returns>
     /// <exception cref="Exception"></exception>
-    public RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart> badParts)
+    public RuleAction Apply(string fieldName, string fieldValue, out List<FailurePart> badParts)
     {
         if (_stream == null)
         {
@@ -83,7 +83,7 @@ public class SocketRule : IAppliableRule, IDisposable
         } while (true);
 
 
-        badParts = HandleResponse(sb.ToString()).ToArray();
+        badParts = HandleResponse(sb.ToString()).ToList();
 
         return badParts.Any() ? RuleAction.Report : RuleAction.None;
     }

--- a/Tests/IsIdentifiableTests/ConsensusRuleTests.cs
+++ b/Tests/IsIdentifiableTests/ConsensusRuleTests.cs
@@ -113,9 +113,9 @@ class ConsensusRuleTests
             _rule = rule;
         }
 
-        public RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart> badParts)
+        public RuleAction Apply(string fieldName, string fieldValue, out List<FailurePart> badParts)
         {
-            badParts = _parts;
+            badParts = new List<FailurePart>(_parts);
 
             return _rule;
         }


### PR DESCRIPTION
Be more specific about what we're actually returning as the `out` list, rather than casting it each time we access it ourselves.